### PR TITLE
📝 Docs: Add architecture documentation and project conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Conventions
+
+## Operational Memory
+
+Where to find things in this repository:
+
+* `README.md` -> Project overview and goals.
+* `wasm-client/` -> The Rust/WebAssembly front-end for reading manpages in the browser.
+* `fetch.py` -> Python script using `nix-index` to fetch manpage archives from the Nix cache (`cache.nixos.org`), extract them using `xz` and `nix nar cat`, and index them into `man2prog.json`.
+* `generate-index` -> Shell script calling `nix-index-database` to generate a list of available manuals to `man.txt`.
+* `devenv.nix` / `devenv.yaml` -> Development environment definitions using `devenv.sh` with Nix, including dependencies like Rust, `wasm-bindgen-cli`, and `wasm-pack`.
+
+## Error Handling
+
+* **Centralized Error Reporting:** All code paths that handle unexpected errors MUST funnel through a centralized error-reporting function. Never call `console.error` directly at the call site for unrecoverable errors. Ensure errors are either propagated or logged with sufficient context (message, stack, relevant metadata).
+* **No Silent Failures:** Every `catch` block, every `.catch()`, or error callback that is not an expected/recoverable condition MUST report the error. Do not swallow exceptions.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Read manpages on the browser.
 Powered by Nix, or at least the consequences of the ecosystem.
 
 It's very experimental and still doesn't work so far.
+
+## Architecture & Flow
+
+This project reads system manuals extracted from Nix archives and displays them on a WebAssembly frontend. The pipeline consists of the following tools:
+
+1. **Index Generation (`generate-index`)**: Generates a raw text file (`man.txt`) detailing the manuals available from the `nix-index-database` by searching for `/man/man[0-9]/.*.gz`.
+2. **Fetching & Extracting (`fetch.py`)**: Consumes the raw text index (`man.txt`), downloads the relevant nar archives from `cache.nixos.org`, extracts the manual files locally using `xz` and `nix nar cat`, and generates a JSON manifest (`man2prog.json`) containing metadata for the manuals.
+3. **Frontend Presentation (`wasm-client`)**: A Rust-based WebAssembly application that is meant to serve as the user interface for parsing and reading the extracted manpages inside the browser.


### PR DESCRIPTION
**Assumptions**
- `AGENTS.md` and conventions specified in `global_instructions` are required foundational documentation for future context, establishing operational memory and central error handling guidelines.
- The pipeline overview details what currently exists in the project (`generate-index`, `fetch.py`, `wasm-client`).

**Alternatives Not Chosen**
- Jumping straight to Rust/Python docstrings. Documenting the high-level architecture and enforcing conventions in `AGENTS.md` provides significantly better orientation for onboarding before granular docstrings are populated.

**How To Pivot**
- If the focus should be on code-level comments instead of markdown documentation, the commit can be reverted. The next step would be specifically augmenting `fetch.py` or `wasm-client/src/lib.rs`.

**Next Knobs**
- Modify `AGENTS.md` to map additional files or adjust the Error Handling convention.
- Expand `README.md` to include setup/running instructions using the provided `devenv.nix` configuration.

---
*PR created automatically by Jules for task [18226849385510417829](https://jules.google.com/task/18226849385510417829) started by @lucasew*