### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection in fetch.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data
 .devenv*
 devenv.local.nix
 
+__pycache__

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-03-21: [Critical RCE] Watch for subprocess.run with shell=True using string interpolation for untrusted input; prefer list arguments and shell=False.

--- a/fetch.py
+++ b/fetch.py
@@ -98,7 +98,8 @@ for drv_hash, v in items_by_hash.items():
             man_file_name = folder_with_hash / man_name
             tempfile_extracted = str(tempfile_download).replace('.xz', '')
             ops.set_description(f"Extracting '{item.path}' from '{tempfile_extracted}'")
-            run(f"nix nar cat '{str(tempfile_extracted)}' '/{item.path}' > '{str(man_file_name.resolve())}'", shell=True, stderr=stderr, stdout=stdout, check=True)
+            with open(man_file_name.resolve(), 'wb') as out_f:
+                run(['nix', 'nar', 'cat', str(tempfile_extracted), f'/{item.path}'], stderr=stderr, stdout=out_f, check=True)
             ops.update(1)
         rmtree(str(tempdir))
     ops.update(len(v))


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Command Injection in fetch.py

**Severity:** CRITICAL
**Vulnerability:** Command Injection via subprocess.run with shell=True
**Impact:** A malicious package/manpath inside the `item.path` or `tempfile_extracted` string could allow arbitrary command execution on the host machine running `fetch.py` since the variables were unescaped and evaluated in a shell context.
**Fix:** Removed `shell=True` and string formatting for the system command. Refactored the `nix nar cat` command to use list arguments and replaced the shell redirect (`>`) with Python's native `open(..., 'wb')` mapping to `stdout`.
**Verification:** Ran unit tests (none existing) and verified the code format. Code review indicates the fix is robust.

**Assumptions**
- The script primarily relies on standard nix store paths and expected formats, but defending against untrusted or malformed inputs is best practice.
- The path mapping `man_file_name.resolve()` represents a safe destination directory.

**Alternatives Not Chosen**
- Using `shlex.quote` on the interpolated strings. While this mitigates the issue while keeping `shell=True`, using a list of arguments is significantly safer and is the recommended pattern in Python for preventing injection.

**How To Pivot**
- If `shell=True` is absolutely strictly required for environment reasons (e.g. running an actual shell script with pipes), use `shlex.quote` to sanitize `tempfile_extracted` and `item.path` prior to formatting the string.

**Next Knobs**
- Modify `fetch.py` line 102 to change the output file handle (`out_f`) mode if binary writes ('wb') are not suitable.
- The journal `.jules/sentinel.md` format can be easily extended if more tracking metadata is needed.

---
*PR created automatically by Jules for task [18274936868718424364](https://jules.google.com/task/18274936868718424364) started by @lucasew*